### PR TITLE
New build target that's compatible with Unity

### DIFF
--- a/Src/Recombee.ApiClient/Bindings/Bookmark.cs
+++ b/Src/Recombee.ApiClient/Bindings/Bookmark.cs
@@ -5,23 +5,23 @@
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 
 using Recombee.ApiClient.Util;
 
 namespace Recombee.ApiClient.Bindings
 {
     /// <summary>Bookmark Binding</summary>
-    [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
     public class Bookmark: RecombeeBinding {
         private readonly string userId;
         /// <summary>User who bookmarked the item</summary>
+        [JsonProperty("userId")]
         public string UserId
         {
             get {return userId;}
         }
         private readonly string itemId;
         /// <summary>Bookmarked item</summary>
+        [JsonProperty("itemId")]
         public string ItemId
         {
             get {return itemId;}
@@ -30,18 +30,21 @@ namespace Recombee.ApiClient.Bindings
         private readonly DateTime? timestamp;
         /// <summary>UTC timestamp of the bookmark as ISO8601-1 pattern or UTC epoch time. The default value is the current time.</summary>
         [JsonConverter(typeof(EpochJsonReader))]
+        [JsonProperty("timestamp")]
         public DateTime? Timestamp
         {
             get {return timestamp;}
         }
         private readonly string recommId;
         /// <summary>If this bookmark is based on a recommendation request, `recommId` is the id of the clicked recommendation.</summary>
+        [JsonProperty("recommId")]
         public string RecommId
         {
             get {return recommId;}
         }
         private readonly Dictionary<string, object> additionalData;
         /// <summary>A dictionary of additional data for the interaction.</summary>
+        [JsonProperty("additionalData")]
         public Dictionary<string, object> AdditionalData
         {
             get {return additionalData;}

--- a/Src/Recombee.ApiClient/Bindings/CartAddition.cs
+++ b/Src/Recombee.ApiClient/Bindings/CartAddition.cs
@@ -5,23 +5,23 @@
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 
 using Recombee.ApiClient.Util;
 
 namespace Recombee.ApiClient.Bindings
 {
     /// <summary>CartAddition Binding</summary>
-    [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
     public class CartAddition: RecombeeBinding {
         private readonly string userId;
         /// <summary>User who added the item to the cart</summary>
+        [JsonProperty("userId")]
         public string UserId
         {
             get {return userId;}
         }
         private readonly string itemId;
         /// <summary>Item added to the cart</summary>
+        [JsonProperty("itemId")]
         public string ItemId
         {
             get {return itemId;}
@@ -30,30 +30,35 @@ namespace Recombee.ApiClient.Bindings
         private readonly DateTime? timestamp;
         /// <summary>UTC timestamp of the cart addition as ISO8601-1 pattern or UTC epoch time. The default value is the current time.</summary>
         [JsonConverter(typeof(EpochJsonReader))]
+        [JsonProperty("timeStamp")]
         public DateTime? Timestamp
         {
             get {return timestamp;}
         }
         private readonly double? amount;
         /// <summary>Amount (number) added to cart. The default is 1. For example if `user-x` adds two `item-y` during a single order (session...), the `amount` should equal to 2.</summary>
+        [JsonProperty("amount")]
         public double? Amount
         {
             get {return amount;}
         }
         private readonly double? price;
         /// <summary>Price of the added item. If `amount` is greater than 1, sum of prices of all the items should be given.</summary>
+        [JsonProperty("price")]
         public double? Price
         {
             get {return price;}
         }
         private readonly string recommId;
         /// <summary>If this cart addition is based on a recommendation request, `recommId` is the id of the clicked recommendation.</summary>
+        [JsonProperty("recommId")]
         public string RecommId
         {
             get {return recommId;}
         }
         private readonly Dictionary<string, object> additionalData;
         /// <summary>A dictionary of additional data for the interaction.</summary>
+        [JsonProperty("additionalData")]
         public Dictionary<string, object> AdditionalData
         {
             get {return additionalData;}

--- a/Src/Recombee.ApiClient/Bindings/DetailView.cs
+++ b/Src/Recombee.ApiClient/Bindings/DetailView.cs
@@ -5,23 +5,23 @@
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 
 using Recombee.ApiClient.Util;
 
 namespace Recombee.ApiClient.Bindings
 {
     /// <summary>DetailView Binding</summary>
-    [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
     public class DetailView: RecombeeBinding {
         private readonly string userId;
         /// <summary>User who viewed the item</summary>
+        [JsonProperty("userId")]
         public string UserId
         {
             get {return userId;}
         }
         private readonly string itemId;
         /// <summary>Viewed item</summary>
+        [JsonProperty("itemId")]
         public string ItemId
         {
             get {return itemId;}
@@ -30,24 +30,28 @@ namespace Recombee.ApiClient.Bindings
         private readonly DateTime? timestamp;
         /// <summary>UTC timestamp of the view as ISO8601-1 pattern or UTC epoch time. The default value is the current time.</summary>
         [JsonConverter(typeof(EpochJsonReader))]
+        [JsonProperty("timestamp")]
         public DateTime? Timestamp
         {
             get {return timestamp;}
         }
         private readonly long? duration;
         /// <summary>Duration of the view</summary>
+        [JsonProperty("duration")]
         public long? Duration
         {
             get {return duration;}
         }
         private readonly string recommId;
         /// <summary>If this detail view is based on a recommendation request, `recommId` is the id of the clicked recommendation.</summary>
+        [JsonProperty("recommId")]
         public string RecommId
         {
             get {return recommId;}
         }
         private readonly Dictionary<string, object> additionalData;
         /// <summary>A dictionary of additional data for the interaction.</summary>
+        [JsonProperty("additionalData")]
         public Dictionary<string, object> AdditionalData
         {
             get {return additionalData;}

--- a/Src/Recombee.ApiClient/Bindings/Entity.cs
+++ b/Src/Recombee.ApiClient/Bindings/Entity.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace Recombee.ApiClient.Bindings
 {
@@ -9,6 +10,7 @@ namespace Recombee.ApiClient.Bindings
         private readonly Dictionary<string, object> values;
         
         /// <summary>Values of properties</summary>
+        [JsonProperty("values")]
         public Dictionary<string, object> Values
         {
             get

--- a/Src/Recombee.ApiClient/Bindings/Group.cs
+++ b/Src/Recombee.ApiClient/Bindings/Group.cs
@@ -5,17 +5,16 @@
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 
 using Recombee.ApiClient.Util;
 
 namespace Recombee.ApiClient.Bindings
 {
     /// <summary>Group Binding</summary>
-    [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
     public class Group: Entity {
         private readonly string groupId;
         /// <summary>Id of the group</summary>
+        [JsonProperty("groupId")]
         public string GroupId
         {
             get {return groupId;}

--- a/Src/Recombee.ApiClient/Bindings/GroupItem.cs
+++ b/Src/Recombee.ApiClient/Bindings/GroupItem.cs
@@ -5,23 +5,23 @@
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 
 using Recombee.ApiClient.Util;
 
 namespace Recombee.ApiClient.Bindings
 {
     /// <summary>GroupItem Binding</summary>
-    [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
     public class GroupItem: RecombeeBinding {
         private readonly string itemType;
         /// <summary>`item` iff the regular item from the catalog is to be inserted, `group` iff group is inserted as the item.</summary>
+        [JsonProperty("itemType")]
         public string ItemType
         {
             get {return itemType;}
         }
         private readonly string itemId;
         /// <summary>ID of the item iff `itemType` is `item`. ID of the group iff `itemType` is `group`.</summary>
+        [JsonProperty("itemId")]
         public string ItemId
         {
             get {return itemId;}

--- a/Src/Recombee.ApiClient/Bindings/Item.cs
+++ b/Src/Recombee.ApiClient/Bindings/Item.cs
@@ -5,17 +5,16 @@
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 
 using Recombee.ApiClient.Util;
 
 namespace Recombee.ApiClient.Bindings
 {
     /// <summary>Item Binding</summary>
-    [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
     public class Item: Entity {
         private readonly string itemId;
         /// <summary>Id of the item</summary>
+        [JsonProperty("itemId")]
         public string ItemId
         {
             get {return itemId;}

--- a/Src/Recombee.ApiClient/Bindings/Logic.cs
+++ b/Src/Recombee.ApiClient/Bindings/Logic.cs
@@ -5,23 +5,23 @@
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 
 using Recombee.ApiClient.Util;
 
 namespace Recombee.ApiClient.Bindings
 {
     /// <summary>Logic Binding</summary>
-    [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
     public class Logic: RecombeeBinding {
         private readonly string name;
         /// <summary>Name of the logic that should be used</summary>
+        [JsonProperty("name")]
         public string Name
         {
             get {return name;}
         }
         private readonly Dictionary<string, object> settings;
         /// <summary>Parameters passed to the logic</summary>
+        [JsonProperty("settings")]
         public Dictionary<string, object> Settings
         {
             get {return settings;}

--- a/Src/Recombee.ApiClient/Bindings/PropertyInfo.cs
+++ b/Src/Recombee.ApiClient/Bindings/PropertyInfo.cs
@@ -5,23 +5,23 @@
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 
 using Recombee.ApiClient.Util;
 
 namespace Recombee.ApiClient.Bindings
 {
     /// <summary>PropertyInfo Binding</summary>
-    [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
     public class PropertyInfo: RecombeeBinding {
         private readonly string name;
         /// <summary>Name of the property</summary>
+        [JsonProperty("name")]
         public string Name
         {
             get {return name;}
         }
         private readonly string type;
         /// <summary>Type of the property</summary>
+        [JsonProperty("type")]
         public string Type
         {
             get {return type;}

--- a/Src/Recombee.ApiClient/Bindings/Purchase.cs
+++ b/Src/Recombee.ApiClient/Bindings/Purchase.cs
@@ -5,23 +5,23 @@
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 
 using Recombee.ApiClient.Util;
 
 namespace Recombee.ApiClient.Bindings
 {
     /// <summary>Purchase Binding</summary>
-    [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
     public class Purchase: RecombeeBinding {
         private readonly string userId;
         /// <summary>User who purchased the item</summary>
+        [JsonProperty("userId")]
         public string UserId
         {
             get {return userId;}
         }
         private readonly string itemId;
         /// <summary>Purchased item</summary>
+        [JsonProperty("itemId")]
         public string ItemId
         {
             get {return itemId;}
@@ -30,36 +30,42 @@ namespace Recombee.ApiClient.Bindings
         private readonly DateTime? timestamp;
         /// <summary>UTC timestamp of the purchase as ISO8601-1 pattern or UTC epoch time. The default value is the current time.</summary>
         [JsonConverter(typeof(EpochJsonReader))]
+        [JsonProperty("timestamp")]
         public DateTime? Timestamp
         {
             get {return timestamp;}
         }
         private readonly double? amount;
         /// <summary>Amount (number) of purchased items. The default is 1. For example if `user-x` purchases two `item-y` during a single order (session...), the `amount` should equal to 2.</summary>
+        [JsonProperty("amount")]
         public double? Amount
         {
             get {return amount;}
         }
         private readonly double? price;
         /// <summary>Price paid by the user for the item. If `amount` is greater than 1, sum of prices of all the items should be given.</summary>
+        [JsonProperty("price")]
         public double? Price
         {
             get {return price;}
         }
         private readonly double? profit;
         /// <summary>Your profit from the purchased item. The profit is natural in e-commerce domain (for example if `user-x` purchases `item-y` for $100 and the gross margin is 30 %, then the profit is $30), but is applicable also in other domains (for example at a news company it may be income from displayed advertisement on article page). If `amount` is greater than 1, sum of profit of all the items should be given.</summary>
+        [JsonProperty("profit")]
         public double? Profit
         {
             get {return profit;}
         }
         private readonly string recommId;
         /// <summary>If this purchase is based on a recommendation request, `recommId` is the id of the clicked recommendation.</summary>
+        [JsonProperty("recommId")]
         public string RecommId
         {
             get {return recommId;}
         }
         private readonly Dictionary<string, object> additionalData;
         /// <summary>A dictionary of additional data for the interaction.</summary>
+        [JsonProperty("additionalData")]
         public Dictionary<string, object> AdditionalData
         {
             get {return additionalData;}

--- a/Src/Recombee.ApiClient/Bindings/Rating.cs
+++ b/Src/Recombee.ApiClient/Bindings/Rating.cs
@@ -5,23 +5,23 @@
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 
 using Recombee.ApiClient.Util;
 
 namespace Recombee.ApiClient.Bindings
 {
     /// <summary>Rating Binding</summary>
-    [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
     public class Rating: RecombeeBinding {
         private readonly string userId;
         /// <summary>User who submitted the rating</summary>
+        [JsonProperty("userId")]
         public string UserId
         {
             get {return userId;}
         }
         private readonly string itemId;
         /// <summary>Rated item</summary>
+        [JsonProperty("itemId")]
         public string ItemId
         {
             get {return itemId;}
@@ -30,24 +30,28 @@ namespace Recombee.ApiClient.Bindings
         private readonly DateTime? timestamp;
         /// <summary>UTC timestamp of the rating as ISO8601-1 pattern or UTC epoch time. The default value is the current time.</summary>
         [JsonConverter(typeof(EpochJsonReader))]
+        [JsonProperty("timestamp")]
         public DateTime? Timestamp
         {
             get {return timestamp;}
         }
         private readonly double rating;
         /// <summary>Rating rescaled to interval [-1.0,1.0], where -1.0 means the worst rating possible, 0.0 means neutral, and 1.0 means absolutely positive rating. For example, in the case of 5-star evaluations, rating = (numStars-3)/2 formula may be used for the conversion.</summary>
+        [JsonProperty("ratingValue")]
         public double RatingValue
         {
             get {return rating;}
         }
         private readonly string recommId;
         /// <summary>If this rating is based on a recommendation request, `recommId` is the id of the clicked recommendation.</summary>
+        [JsonProperty("recommId")]
         public string RecommId
         {
             get {return recommId;}
         }
         private readonly Dictionary<string, object> additionalData;
         /// <summary>A dictionary of additional data for the interaction.</summary>
+        [JsonProperty("additionalData")]
         public Dictionary<string, object> AdditionalData
         {
             get {return additionalData;}

--- a/Src/Recombee.ApiClient/Bindings/Series.cs
+++ b/Src/Recombee.ApiClient/Bindings/Series.cs
@@ -5,17 +5,16 @@
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 
 using Recombee.ApiClient.Util;
 
 namespace Recombee.ApiClient.Bindings
 {
     /// <summary>Series Binding</summary>
-    [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
     public class Series: Entity {
         private readonly string seriesId;
         /// <summary>Id of the series</summary>
+        [JsonProperty("seriesId")]
         public string SeriesId
         {
             get {return seriesId;}

--- a/Src/Recombee.ApiClient/Bindings/SeriesItem.cs
+++ b/Src/Recombee.ApiClient/Bindings/SeriesItem.cs
@@ -5,29 +5,30 @@
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 
 using Recombee.ApiClient.Util;
 
 namespace Recombee.ApiClient.Bindings
 {
     /// <summary>SeriesItem Binding</summary>
-    [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
     public class SeriesItem: RecombeeBinding {
         private readonly string itemType;
         /// <summary>`item` iff the regular item from the catalog is to be inserted, `series` iff series is inserted as the item.</summary>
+        [JsonProperty("itemType")]
         public string ItemType
         {
             get {return itemType;}
         }
         private readonly string itemId;
         /// <summary>ID of the item iff `itemType` is `item`. ID of the series iff `itemType` is `series`.</summary>
+        [JsonProperty("itemId")]
         public string ItemId
         {
             get {return itemId;}
         }
         private readonly double time;
         /// <summary>Time index used for sorting items in the series. According to time, items are sorted within series in ascending order. In the example of TV show episodes, the episode number is a natural choice to be passed as time.</summary>
+        [JsonProperty("time")]
         public double Time
         {
             get {return time;}

--- a/Src/Recombee.ApiClient/Bindings/User.cs
+++ b/Src/Recombee.ApiClient/Bindings/User.cs
@@ -5,17 +5,16 @@
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 
 using Recombee.ApiClient.Util;
 
 namespace Recombee.ApiClient.Bindings
 {
     /// <summary>User Binding</summary>
-    [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
     public class User: Entity {
         private readonly string userId;
         /// <summary>Id of the user</summary>
+        [JsonProperty("userId")]
         public string UserId
         {
             get {return userId;}

--- a/Src/Recombee.ApiClient/Bindings/ViewPortion.cs
+++ b/Src/Recombee.ApiClient/Bindings/ViewPortion.cs
@@ -5,35 +5,37 @@
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 
 using Recombee.ApiClient.Util;
 
 namespace Recombee.ApiClient.Bindings
 {
     /// <summary>ViewPortion Binding</summary>
-    [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
     public class ViewPortion: RecombeeBinding {
         private readonly string userId;
         /// <summary>User who viewed a portion of the item</summary>
+        [JsonProperty("userId")]
         public string UserId
         {
             get {return userId;}
         }
         private readonly string itemId;
         /// <summary>Viewed item</summary>
+        [JsonProperty("itemId")]
         public string ItemId
         {
             get {return itemId;}
         }
         private readonly double portion;
         /// <summary>Viewed portion of the item (number between 0.0 (viewed nothing) and 1.0 (viewed full item) ). It should be the really viewed part of the item, no matter seeking, so for example if the user seeked immediately to half of the item and then viewed 10% of the item, the `portion` should still be `0.1`.</summary>
+        [JsonProperty("portion")]
         public double Portion
         {
             get {return portion;}
         }
         private readonly string sessionId;
         /// <summary>ID of session in which the user viewed the item. Default is `null` (`None`, `nil`, `NULL` etc. depending on language).</summary>
+        [JsonProperty("sessionId")]
         public string SessionId
         {
             get {return sessionId;}
@@ -42,18 +44,21 @@ namespace Recombee.ApiClient.Bindings
         private readonly DateTime? timestamp;
         /// <summary>UTC timestamp of the rating as ISO8601-1 pattern or UTC epoch time. The default value is the current time.</summary>
         [JsonConverter(typeof(EpochJsonReader))]
+        [JsonProperty("timestamp")]
         public DateTime? Timestamp
         {
             get {return timestamp;}
         }
         private readonly string recommId;
         /// <summary>If this view portion is based on a recommendation request, `recommId` is the id of the clicked recommendation.</summary>
+        [JsonProperty("recommId")]
         public string RecommId
         {
             get {return recommId;}
         }
         private readonly Dictionary<string, object> additionalData;
         /// <summary>A dictionary of additional data for the interaction.</summary>
+        [JsonProperty("additionalData")]
         public Dictionary<string, object> AdditionalData
         {
             get {return additionalData;}

--- a/Src/Recombee.ApiClient/Recombee.ApiClient.csproj
+++ b/Src/Recombee.ApiClient/Recombee.ApiClient.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard1.3;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" Condition="'$(TargetFramework)' != 'net452'" />
+    <PackageReference Include="Newtonsoft.Json" Version="8.0.3" Condition="'$(TargetFramework)' == 'net452'" />
     <PackageReference Include="System.Net.Http" Version="4.3.3" />
   </ItemGroup>
 


### PR DESCRIPTION
The only reliable (for il2cpp builds on mobile devices) newtonsoft JSON.NET library for Unity is based on version 8.0 (https://assetstore.unity.com/packages/tools/input-management/json-net-for-unity-11347)
Create a .net 4.5 build target for Unity export
Using the older 8.0 version of JSON.NET for this target to match what's supported in Unity
Add explicate json property names
Removing NamingStrategyType references as that feature isn't availble in JSON.NET version 8.0